### PR TITLE
負荷テストツール用のエンドポイント修正

### DIFF
--- a/app/crud.py
+++ b/app/crud.py
@@ -263,8 +263,8 @@ def create_ticket(db:Session,event:schemas.Event,user:schemas.JWTUser,person:int
     db.commit()
     db.refresh(db_ticket)
     return db_ticket
-def spectest_ticket(db:Session,user:schemas.JWTUser):
-    db_ticket = models.Ticket(id=ulid.new().str,group_id="testgroup",event_id="01H9PTVFH7CS30A5RKBKMAQ82R",owner_id=user.name,person=1,status="cancelled",created_at=datetime.now(timezone(timedelta(hours=+9))).isoformat())
+def spectest_ticket(group_id:str, event_id:str ,db:Session,user:schemas.JWTUser):
+    db_ticket = models.Ticket(id=ulid.new().str,group_id=group_id,event_id=event_id,owner_id=user.name,person=1,status="active",created_at=datetime.now(timezone(timedelta(hours=+9))).isoformat())
     db.add(db_ticket)
     db.commit()
     db.refresh(db_ticket)

--- a/docker_startup.sh
+++ b/docker_startup.sh
@@ -5,4 +5,4 @@ pip install -r ./requirements.txt
 wait
 chmod +x ./wait-for-it.sh
 bash ./wait-for-it.sh db:3306 -t 60 -- alembic upgrade head
-uvicorn app.main:app --host 0.0.0.0 --reload
+uvicorn app.main:app --host 0.0.0.0 --reload --log-level debug


### PR DESCRIPTION
同じアカウントで複数のチケットを取得できるエンドポイントを追加
引数 group_id, event_id
作られたチケットの状態はactiveとしてperson=1で作成される