### PR TITLE
認証が必要なエンドポイントはJWTの検証をバイパスしてテスト出来るように

### DIFF
--- a/app/test/conftest.py
+++ b/app/test/conftest.py
@@ -9,12 +9,26 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy_utils import create_database, database_exists
 
-DATABASE_URI = "mysql://"+ settings.mysql_user +":"+ settings.mysql_password +"@"+ settings.db_host +"/quaint-app"
+TEST_DATABASE_URI = "mysql://"+ settings.mysql_user +":"+ settings.mysql_password +"@"+ settings.db_host +"/quaint-app-test"
 
-@pytest.fixture(scope="function")
+### データベースのfixture
+# 各テストケースが実行されるごとに、データベースを他のテストの影響を受けない(=全て削除された)クリーンな状態にしたうえで、DBへの接続を提供する
+
+### ./utils/overrides.pyの app.dependency_overrides[get_db] = override_get_db と混同しそうだが
+## test/conftest.pyでは
+# テスト用テーブルが無ければ作成、各テストケース終了後のクリーンアップといった、「前処理・後処理」を担当している
+# (必要であれば)加えて、テスト「する」側である、app/test/以下で定義されているテスト関数たちにテスト用DBへの接続を提供している
+# (テストの前処理として、APIを経由せずデータベースに直接レコードを追加したかったりするので)
+# Pytestモジュールのfixture関数をデコレートすることで実現している
+## 対してtest/utils/overrides.pyでは
+# テスト「される」側である、app/main.pyで定義されている各エンドポイントなどが利用するDB接続をオーバーライドしている
+# app/main.pyで定義されている各エンドポイントはFastAPIライブラリのFastAPIクラスのメンバ関数であるFastAPI.get()などをデコレートしているので
+# FastAPIクラスのインスタンスであるapp.main.appに対して、app.dependency_overrides[get_db] = override_get_db などとすることで、FastAPIライブラリが良しなにやってくれている
+
+@pytest.fixture(scope="function",autouse=True)
 def db() -> Generator[Session, None, None]:
-    if not database_exists(DATABASE_URI):
-        create_database(DATABASE_URI)
+    if not database_exists(TEST_DATABASE_URI):
+        create_database(TEST_DATABASE_URI)
 
     Base.metadata.create_all(bind=engine)
     session = TestingSessionLocal()

--- a/app/test/factories.py
+++ b/app/test/factories.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict
 from factory.alchemy import SQLAlchemyModelFactory
 
 import datetime
@@ -8,40 +9,37 @@ from app import schemas
 from app.test.utils.overrides import TestingSessionLocal
 
 ### schemas.JWTUser
-class MockAuthHeaderBase:
-    def __new__(self) -> str:
-        return {'Authorization': json.dumps(self.user)}
-    user=[{}]
-class ValidAdminUser(MockAuthHeaderBase):
-    user={
-        "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
-        "groups": [
-            "5c091517-25de-44bc-9e42-ffcb8539435c", # quaint-admin
-        ],
-        "name": "adminfortest",
-        "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
-        "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
-    }
-class InvalidAdminUser1(MockAuthHeaderBase):
-    user={
-        "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
-        "groups": [
-            "5c091517-25de-44bc-9e42-ffcb8539435", # 1 charactor missing
-        ],
-        "name": "adminfortest",
-        "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
-        "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
-    }
-class InvalidAdminUser2(MockAuthHeaderBase):
-    user={
-        "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
-        "groups": [
-            "invaliduuid", # 1 charactor missing
-        ],
-        "name": "adminfortest",
-        "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
-        "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
-    }
+def authheader(user:Dict):
+    return {'Authorization': json.dumps(user)}
+
+valid_admin_user={
+    "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
+    "groups": [
+        "5c091517-25de-44bc-9e42-ffcb8539435c", # quaint-admin
+    ],
+    "name": "adminfortest",
+    "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
+    "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
+}
+invalid_admin_user1={
+    "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
+    "groups": [
+        "5c091517-25de-44bc-9e42-ffcb8539435", # 1 charactor missing
+    ],
+    "name": "adminfortest",
+    "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
+    "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
+}
+
+invalid_admin_user2={
+    "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
+    "groups": [
+        "invaliduuid", # 1 charactor missing
+    ],
+    "name": "adminfortest",
+    "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
+    "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
+}
 
 valid_single_group=[{
     "id":"28r",

--- a/app/test/factories.py
+++ b/app/test/factories.py
@@ -1,3 +1,4 @@
+import json
 from factory.alchemy import SQLAlchemyModelFactory
 
 import datetime
@@ -5,6 +6,90 @@ import datetime
 from app import models
 from app import schemas
 from app.test.utils.overrides import TestingSessionLocal
+
+### schemas.JWTUser
+class MockAuthHeaderBase:
+    def __new__(self) -> str:
+        return {'Authorization': json.dumps(self.user)}
+    user=[{}]
+class ValidAdminUser(MockAuthHeaderBase):
+    user={
+        "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
+        "groups": [
+            "5c091517-25de-44bc-9e42-ffcb8539435c", # quaint-admin
+        ],
+        "name": "adminfortest",
+        "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
+        "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
+    }
+class InvalidAdminUser1(MockAuthHeaderBase):
+    user={
+        "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
+        "groups": [
+            "5c091517-25de-44bc-9e42-ffcb8539435", # 1 charactor missing
+        ],
+        "name": "adminfortest",
+        "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
+        "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
+    }
+class InvalidAdminUser2(MockAuthHeaderBase):
+    user={
+        "iss": "https://login.microsoftonline.com/158e6d17-f3d5-4365-8428-26dfc74a9d27/v2.0",
+        "groups": [
+            "invaliduuid", # 1 charactor missing
+        ],
+        "name": "adminfortest",
+        "oid": "25e3cf28-e627-4dfe-b5dd-bdcbe73117e1", # random
+        "sub": "BEGuhvmm8LkWHLxEK9TxDkVaMvK3nDGq6ak79HPGLsd", # random
+    }
+
+valid_single_group=[{
+    "id":"28r",
+    "type":"play",
+    "groupname":"2年8組",
+    "title":"SING",
+    "description":"ここに説明文",
+    "enable_vote":True,
+    "twitter_url":None,
+    "instagram_url":None,
+    "stream_url":None,
+    "public_thumbnail_image_url":None,
+    "public_page_content_url":"<html><h1>宣伝ページ</h1></html>",
+    "private_page_content_url":"<html><h1>プライベート</h1></html>",
+    "floor":1,
+    "place":"社会科教室"
+    }]
+
+valid_multiple_groups=[
+    {"id":"28r",
+    "type":"play",
+    "groupname":"2年8組",
+    "title":"SING",
+    "description":"ここに説明文",
+    "enable_vote":True,
+    "twitter_url":None,
+    "instagram_url":None,
+    "stream_url":None,
+    "public_thumbnail_image_url":None,
+    "public_page_content_url":"<html><h1>宣伝ページ</h1></html>",
+    "private_page_content_url":"<html><h1>プライベート</h1></html>",
+    "floor":1,
+    "place":"社会科教室"},
+    {"id":"17r",
+    "groupname":"1年7組",
+    "title":"hatopoppo",
+    "description":"ここに説明文",
+    "enable_vote":True,
+    "twitter_url":None,
+    "instagram_url":None,
+    "stream_url":None,
+    "public_thumbnail_image_url":None,
+    "public_page_content_url":"<html><h1>宣伝ページ</h1></html>",
+    "private_page_content_url":"<html><h1>プライベート</h1></html>",
+    "floor":2,
+    "place":"生徒ホール",
+    "type":schemas.GroupType.play}]
+
 
 class tag1_TagCreateByAdmin():
     tagname="タグ1"

--- a/app/test/factories.py
+++ b/app/test/factories.py
@@ -6,49 +6,6 @@ from app import models
 from app import schemas
 from app.test.utils.overrides import TestingSessionLocal
 
-class Admin_UserCreateByAdmin():
-    username = "admin"
-    password = "password"
-    is_student=True
-    is_family=False
-    is_active=False
-    password_expired=False
-
-class hogehoge_UserCreateByAdmin():
-    username = "hoge_hoge"
-    password = "password"
-    is_student=False
-    is_family=False
-    is_active=False
-    password_expired=False
-class passwordexpired_UserCreateByAdmin():
-    username = "hoge_hoge"
-    password = "password"
-    is_student=False
-    is_family=False
-    is_active=False
-    password_expired=True
-class active_UserCreateByAdmin():
-    username = "active_hoge_hoge"
-    password = "password"
-    is_student=False
-    is_family=False
-    is_active=True
-    password_expired=False
-class inactive_UserCreateByAdmin():
-    username = "active_hoge_hoge"
-    password = "password"
-    is_student=False
-    is_family=False
-    is_active=False
-    password_expired=False
-class active_student_UserCreateByAdmin():
-    username = "active_hoge_hoge"
-    password = "password"
-    is_student=True
-    is_family=False
-    is_active=True
-    password_expired=False
 class tag1_TagCreateByAdmin():
     tagname="タグ1"
 class tag2_TagCreateByAdmin():

--- a/app/test/test_auth.py
+++ b/app/test/test_auth.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from app.main import app
+from app.auth import verify_jwt
+from app.test.utils.overrides import override_verify_jwt
+
+client=TestClient(app)
+
+### test/overrides.pyによってバイパスしてしまっているapp.auth.verify_jwt()自体のテストをする
+# EntraIDから正しいトークンを自動で取得して成功することを確認するテストは難しくても、間違ったトークンではしっかり失敗することだけでもテストしたい
+
+# verify_jwt()に依存しているエンドポイントの例として、"/users/me/tickets"を使っている
+# このやり方がベストなのかわからない。本当は関数単体でテスト出来るといいんだけど
+def test_verify_jwt_fail():
+    app.dependency_overrides[verify_jwt]=verify_jwt # test/overrides.pyでoverrideした依存関係を元に戻す
+    response=client.get("/users/me/tickets",headers={'Authorization':"Bearer invalid.jwt.token"}) # もっといろんなパターンのinvalidなトークン(payloadはvalidだがsignatureがinvalid,有効期限だけinvalid...など)を試すべき？
+    assert response.status_code==401
+    app.dependency_overrides[verify_jwt]=override_verify_jwt # 再びoverride
+

--- a/app/test/test_main.py
+++ b/app/test/test_main.py
@@ -39,7 +39,7 @@ def test_get_all_groups(db):
 
 
 def test_create_multiple_group_success():
-    response = client.post(url="/groups",json=factories.valid_multiple_groups,headers=factories.ValidAdminUser())
+    response = client.post(url="/groups",json=factories.valid_multiple_groups,headers=factories.authheader(factories.valid_admin_user))
     assert response.status_code==200
 
 #もっと細かく書けるかも(https://nmomos.com/tips/2021/03/07/fastapi-docker-8/#toc_id_2)

--- a/app/test/test_main.py
+++ b/app/test/test_main.py
@@ -1,8 +1,8 @@
 import datetime
+import json
 from urllib import response
 
 from app import crud, schemas, models
-from app import db
 from app.config import settings
 from app.main import app
 from app.test import factories
@@ -36,5 +36,10 @@ def test_get_all_groups(db):
     response = client.get("/groups")
 
     assert response.status_code == 200
+
+
+def test_create_multiple_group_success():
+    response = client.post(url="/groups",json=factories.valid_multiple_groups,headers=factories.ValidAdminUser())
+    assert response.status_code==200
 
 #もっと細かく書けるかも(https://nmomos.com/tips/2021/03/07/fastapi-docker-8/#toc_id_2)

--- a/app/test/utils/overrides.py
+++ b/app/test/utils/overrides.py
@@ -6,6 +6,20 @@ from app.main import app
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+### DBのオーバーライド
+# テストでは一旦データベースをまっさらな状態にしテスト用のデータを投入する、ということを繰り返す
+# そのため開発者のPCで動作している開発用のデータベースなどがぐちゃぐちゃになることを防ぐためテスト用の別のテーブルに接続させる
+
+### ../conftest.py の @pytest.fixtureと混同しそうだが
+## test/utils/overrides.pyでは
+# テスト「される」側である、app/main.pyで定義されている各エンドポイントなどが利用するDB接続をオーバーライドしている
+# app/main.pyで定義されている各エンドポイントはFastAPIライブラリのFastAPIクラスのメンバ関数であるFastAPI.get()などをデコレートしているので
+# FastAPIクラスのインスタンスであるapp.main.appに対して、app.dependency_overrides[get_db] = override_get_db などとすることで、FastAPIライブラリが良しなにやってくれている
+## 対して、test/conftest.pyでは
+# テスト用テーブルが無ければ作成、各テストケース終了後のクリーンアップといった、「前処理・後処理」を担当している
+# (必要であれば)加えて、テスト「する」側である、app/test/以下で定義されているテスト関数たちにテスト用DBへの接続を提供している
+# (テストの前処理として、APIを経由せずデータベースに直接レコードを追加したかったりするので)
+# これまたPytestモジュールのfixture関数をデコレートすることで実現している
 TEST_DATABASE_URI = "mysql://"+ settings.mysql_user +":"+ settings.mysql_password +"@"+ settings.db_host +"/quaint-app-test"
 
 engine = create_engine(TEST_DATABASE_URI)


### PR DESCRIPTION
しました。

今まで俺も理解せずただドキュメント通りに書いていた、テスト用DBのfixtureとoverrideの違いについて調べてコメント(およびscrapbox)書いたからぜひ読んでください

ところで、検証をバイパスするならテストする意味無いのでは？と一瞬思っちゃったけど

- パスパラメータやリクエストボディなどの処理が仕様通りか
  - これらはTestClientを使って実際にFastAPIにリクエストしないとテスト出来ないから
- 仕様通りの応答が返ってくるか
  - ステータスコードやJSONの形式など
- 仕様通りの権限になっているか
  - Depends(auth.admin)とするつもりのところをDepends(auth.get_current_user)としてしまうような凡ミスを防ぐ

をテストすることができるようになるから意味はあるはず