### PR TITLE
initializeCommandを変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
   // connected. This is typically a file mount in .devcontainer/docker-compose.yml
   "workspaceFolder": "/workspace",
 
-  "initializeCommand": "cp app/.env.docker app/.env -n", // .envが無ければdockerコンテナの作成に最低限必要なものだけコピーする(これが無いとcodespaces使えない)
+  "initializeCommand": "cp app/.env.docker app/.env", // .envが無ければdockerコンテナの作成に最低限必要なものだけコピーする(これが無いとcodespaces使えない)
 
   "customizations": {
     // Configure properties specific to VS Code.


### PR DESCRIPTION
Member
[MRharu0310](https://github.com/MRharu0310) commented [10 minutes ago](https://github.com/hibiya-itchief/2024-quaint-api/pull/49#issue-2473702021)
Dockerでフォルダ開く時に、
"initializeCommand": "cp app/.env.docker app/.env -n"
これだとエラーが出て、
"initializeCommand": "cp -n app/.env.docker app/.env"
にして解決しました
問題があれば直します